### PR TITLE
fix: schedule resize call in BufEnter autocmd

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -48,8 +48,7 @@ function M.setup(config)
 			{
 				'BufEnter',
 				'*',
-				'doautocmd WinScrolled | lua require"focus".resize()',
-				-- 'lua vim.schedule(function() require"focus".resize(); vim.cmd([[doautocmd WinScrolled]]) end)',
+				'lua vim.schedule(function() require"focus".resize(); vim.cmd([[doautocmd WinScrolled]]) end)',
 			},
 			{ 'WinEnter,BufEnter', 'NvimTree_*', 'lua require"focus".resize()' },
 		}


### PR DESCRIPTION
This partially reverts 6ff7636, which itself removed this scheduling behavior that was introduced in 408f250.  Scheduling resize to be called at the end of the event loop helps focus interop with other plugins better.

Fixes #100