### PR TITLE
fix(resize): ignore floating windows

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -22,7 +22,11 @@ local golden_ratio_minheight = function()
 end
 
 function M.split_resizer(config) --> Only resize normal buffers, set qf to 10 always
-    if utils.is_disabled() or vim.api.nvim_win_get_option(0, 'diff') then
+    if
+        utils.is_disabled()
+        or vim.api.nvim_win_get_option(0, 'diff')
+        or vim.api.nvim_win_get_config(0).relative ~= ''
+    then
         vim.o.winminwidth = 1
         vim.o.winwidth = 1
         vim.o.winminheight = 1


### PR DESCRIPTION
This fixes the issue with Telescope that I [mentioned](https://github.com/nvim-focus/focus.nvim/pull/106#issuecomment-1613602693), as well as an issue I was having where the LSP hover window was always too large. As far as I know floating windows shouldn't be resized, so this uses `vim.api.nvim_win_get_config` to check if the window is floating before resizing.