### PR TITLE
fix: wrap `vim.api.nvim_command` in pcall

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -61,7 +61,7 @@ function M.setup(config)
                 -- If we switch between horizontal splits, center the window
                 if cur_win_pos[2] == prev_win_pos[2] then
                     vim.api.nvim_win_call(previous_win_id, function()
-                        vim.api.nvim_command('normal! zz')
+                        pcall(vim.api.nvim_command, 'normal! zz')
                     end)
                 end
             end,

--- a/tests/test_autoresize.lua
+++ b/tests/test_autoresize.lua
@@ -236,4 +236,17 @@ T['autoresize']['quickfix'] = function()
     validate_win_dims(win_id_lower, { 80, 10 })
 end
 
+T['autoresize']['terminal'] = function()
+    -- create a new term split
+    child.cmd('split')
+    child.cmd('terminal')
+    -- enter terminal insert mode
+    child.cmd('startinsert!')
+
+    -- Switch to the upper window
+    -- Without pcall, this throws an error because `normal!` doesn't
+    -- work from terminal mode.
+    child.cmd('wincmd w')
+end
+
 return T


### PR DESCRIPTION
This call fails when the current window is a terminal and is in terminal mode. Wrapping it in pcall gets rid of the issue even if it's a bit of a dirty fix.