### PR TITLE
fix: set vim.g.focus_disable on disable

### DIFF
--- a/lua/focus/modules/functions.lua
+++ b/lua/focus/modules/functions.lua
@@ -16,7 +16,7 @@ M.focus_disable = function()
         return
     end
 
-    vim.g.enabled_focus_resizing = 0
+    vim.g.focus_disable = true
     vim.o.winminwidth = 0
     vim.o.winwidth = 20
     vim.o.winminheight = 1


### PR DESCRIPTION
The focus_disable function was still setting the legacy `enabled_focus_resizing` option, which is no longer used anywhere else. This just looks to be an oversight in 1aa0a6b or 493a9da.