### PR TITLE
refactor: move command defs to lua, use vim.split

### DIFF
--- a/lua/focus/modules/commands.lua
+++ b/lua/focus/modules/commands.lua
@@ -1,27 +1,102 @@
-local vim = vim
 local M = {}
 
+M.commands = {
+    FocusDisable = {
+        function()
+            require('focus').focus_disable()
+        end,
+        { nargs = 0 },
+    },
+    FocusEnable = {
+        function()
+            require('focus').focus_enable()
+        end,
+        { nargs = 0 },
+    },
+    FocusToggle = {
+        function()
+            require('focus').focus_toggle()
+        end,
+        { nargs = 0 },
+    },
+    FocusDisableWindow = {
+        function()
+            require('focus').focus_disable_window()
+        end,
+        { nargs = 0 },
+    },
+    FocusEnableWindow = {
+        function()
+            require('focus').focus_enable_window()
+        end,
+        { nargs = 0 },
+    },
+    FocusToggleWindow = {
+        function()
+            require('focus').focus_toggle_window()
+        end,
+        { nargs = 0 },
+    },
+    FocusEqualise = {
+        function()
+            require('focus').focus_equalise()
+        end,
+        { nargs = 0 },
+    },
+    FocusMaximise = {
+        function()
+            require('focus').focus_maximise()
+        end,
+        { nargs = 0 },
+    },
+    FocusMaxOrEqual = {
+        function()
+            require('focus').focus_max_or_equal()
+        end,
+        { nargs = 0 },
+    },
+    FocusSplitNicely = {
+        function(obj)
+            require('focus').split_nicely(obj.args)
+        end,
+        { nargs = '?', complete = 'file' },
+    },
+    FocusSplitCycle = {
+        function(obj)
+            require('focus').split_cycle(obj.args)
+        end,
+        { nargs = '?' },
+    },
+    FocusSplitLeft = {
+        function(obj)
+            require('focus').split_command('h', obj.args)
+        end,
+        { nargs = '?', complete = 'file' },
+    },
+    FocusSplitDown = {
+        function(obj)
+            require('focus').split_command('j', obj.args)
+        end,
+        { nargs = '?', complete = 'file' },
+    },
+    FocusSplitUp = {
+        function(obj)
+            require('focus').split_command('k', obj.args)
+        end,
+        { nargs = '?', complete = 'file' },
+    },
+    FocusSplitRight = {
+        function(obj)
+            require('focus').split_command('l', obj.args)
+        end,
+        { nargs = '?', complete = 'file' },
+    },
+}
+
 M.setup = function()
-    vim.api.nvim_exec(
-        [[
-command! -nargs=0 FocusDisable lua require('focus').focus_disable()
-command! -nargs=0 FocusEnable lua require('focus').focus_enable()
-command! -nargs=0 FocusToggle lua require('focus').focus_toggle()
-command! -nargs=0 FocusDisableWindow lua require('focus').focus_disable_window()
-command! -nargs=0 FocusEnableWindow lua require('focus').focus_enable_window()
-command! -nargs=0 FocusToggleWindow lua require('focus').focus_toggle_window()
-command! -nargs=0 FocusEqualise lua require('focus').focus_equalise()
-command! -nargs=0 FocusMaximise lua require('focus').focus_maximise()
-command! -nargs=0 FocusMaxOrEqual lua require('focus').focus_max_or_equal()
-command! -nargs=? -complete=file FocusSplitNicely lua require('focus').split_nicely(<q-args>)
-command! -nargs=? FocusSplitCycle lua require('focus').split_cycle(<q-args>)
-command! -nargs=? -complete=file FocusSplitLeft lua require('focus').split_command("h", <q-args>)
-command! -nargs=? -complete=file FocusSplitDown lua require('focus').split_command("j", <q-args>)
-command! -nargs=? -complete=file FocusSplitUp lua require('focus').split_command("k", <q-args>)
-command! -nargs=? -complete=file FocusSplitRight lua require('focus').split_command("l", <q-args>)
-]],
-        false
-    )
+    for name, def in pairs(M.commands) do
+        vim.api.nvim_create_user_command(name, def[1], def[2])
+    end
 end
 
 return M

--- a/lua/focus/modules/split.lua
+++ b/lua/focus/modules/split.lua
@@ -6,7 +6,7 @@ local M = {}
 local golden_ratio = 1.618
 
 local function process_split_args(created, args, bufnew)
-    local args_array = utils.split(args, ' ')
+    local args_array = vim.split(args, ' ')
     if args_array[1] ~= '' and args_array[1] ~= 'cmd' then
         cmd('edit ' .. args_array[1])
     elseif args_array[1] == 'cmd' and args_array[2] ~= nil then

--- a/lua/focus/modules/utils.lua
+++ b/lua/focus/modules/utils.lua
@@ -28,15 +28,6 @@ function M.remove_from_set(set, item)
     return set
 end
 
--- SPLITS A STRING BY SPACE FOR : COMMAND PARSING
-function M.split(s, delimiter)
-    local result = {}
-    for match in (s .. delimiter):gmatch('(.-)' .. delimiter) do
-        table.insert(result, match)
-    end
-    return result
-end
-
 M.is_disabled = function()
     return vim.g.focus_disable == true or vim.b.focus_disable == true
 end


### PR DESCRIPTION
Moves command definitions to Lua, and uses vim.split to split args instead of a Lua pattern.
