### PR TITLE
fix: Add missing utils.is_disabled() check

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -201,6 +201,9 @@ function M.setup(config)
             vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
                 group = augroup,
                 callback = function(_)
+                    if utils.is_disabled() then
+                        return
+                    end
                     vim.wo.number = true
                     vim.wo.relativenumber = true
                 end,


### PR DESCRIPTION
Add `utils.is_disabled()` check when `hybridnumber` and `absolutenumber_unfocused` are both set to true.