### PR TITLE
Add config for Selene linter

### DIFF
--- a/neovim.yml
+++ b/neovim.yml
@@ -1,0 +1,6 @@
+---
+base: lua51
+
+globals:
+  vim:
+    any: true

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,5 @@
+std = "lua51+neovim"
+
+[rules]
+global_usage = "allow"
+multiple_statements = "allow"


### PR DESCRIPTION
Tells selene about the `vim` global so that unnecessary warnings are silenced.