### PR TITLE
fix: remove unnecessary uses of nvim_win_call

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -71,14 +71,15 @@ function M.maximise()
     local view = vim.fn.winsaveview()
     vim.api.nvim_win_set_width(win, width)
     vim.api.nvim_win_set_height(win, height)
-    vim.api.nvim_win_call(function()
-        vim.fn.winrestview(view)
-    end)
+    vim.fn.winrestview(view)
 end
 
 M.goal = 'autoresize'
 
 function M.split_resizer(config, goal) --> Only resize normal buffers, set qf to 10 always
+    if goal then
+        M.goal = goal
+    end
     if
         utils.is_disabled()
         or vim.api.nvim_win_get_option(0, 'diff')
@@ -103,10 +104,6 @@ function M.split_resizer(config, goal) --> Only resize normal buffers, set qf to
             end
             vim.o.winminheight = config.autoresize.minheight
         end
-    end
-
-    if goal then
-        M.goal = goal
     end
 
     if vim.bo.filetype == 'qf' and config.autoresize.height_quickfix > 0 then

--- a/tests/test_autoresize.lua
+++ b/tests/test_autoresize.lua
@@ -241,4 +241,42 @@ T['autoresize']['terminal'] = function()
     child.cmd('wincmd w')
 end
 
+T['autoresize']['maximize'] = function()
+    reload_module({ autoresize = {} })
+    child.cmd('vsplit')
+    child.cmd('FocusMaximise')
+
+    local resize_state = child.get_resize_state()
+    local win_id_left = resize_state.windows[1]
+    local win_id_right = resize_state.windows[2]
+
+    -- we should be in the left win
+    eq(win_id_left, child.api.nvim_get_current_win())
+
+    -- let should take up the entire width, other than the winseparator (1 col)
+    -- and numbercolumn (1 col)
+    validate_win_dims(win_id_left, { 78, 23 })
+    validate_win_dims(win_id_right, { 1, 23 })
+end
+
+T['autoresize']['maximize_minwidth'] = function()
+    reload_module({ autoresize = {
+        minwidth = 12,
+    } })
+    child.cmd('vsplit')
+    child.cmd('FocusMaximise')
+
+    local resize_state = child.get_resize_state()
+    local win_id_left = resize_state.windows[1]
+    local win_id_right = resize_state.windows[2]
+
+    -- we should be in the left win
+    eq(win_id_left, child.api.nvim_get_current_win())
+
+    -- let should take up the entire width, other than the winseparator (1 col)
+    -- and numbercolumn (1 col)
+    validate_win_dims(win_id_left, { 67, 23 })
+    validate_win_dims(win_id_right, { 12, 23 })
+end
+
 return T


### PR DESCRIPTION
fix: remove unnecessary uses of nvim_win_call

(moving immediate autoresize to another PR as it needs test changes)

closes #122