### PR TITLE
Remove window centering logic since it's built into nvim with `:h splitkeep`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ require("focus").setup({
 })
 ```
 
+> **Note**
+> To manage window views when resizing, see `:h splitkeep`.<br>
+> For users of Neovim <= 0.8, it is recommended to use the
+> [stabilize](https://github.com/luukvbaal/stabilize.nvim) plugin.
+
 ### Setup options
 
 **Enable/Disable Focus**

--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -44,50 +44,6 @@ function M.setup(config)
             end,
             desc = 'Resize splits',
         })
-        vim.api.nvim_create_autocmd('WinEnter', {
-            group = augroup,
-            callback = function(_)
-                local current_win_id = vim.api.nvim_get_current_win()
-
-                -- If we have a horizontal split, center the window so we keep
-                -- the current line in view.
-                if previous_win_id == 0 then
-                    return
-                end
-
-                -- Don't center if the previous buffer was a terminal
-                local prev_win_buf = vim.api.nvim_win_get_buf(previous_win_id)
-                if vim.bo[prev_win_buf].buftype == 'terminal' then
-                    return
-                end
-
-                local cur_win_pos = vim.fn.win_screenpos(current_win_id)
-                local prev_win_pos = vim.fn.win_screenpos(previous_win_id)
-
-                -- If we switch between horizontal splits, center the window
-                if cur_win_pos[2] == prev_win_pos[2] then
-                    vim.api.nvim_win_call(previous_win_id, function()
-                        pcall(vim.api.nvim_command, 'normal! zz')
-                    end)
-                end
-            end,
-            desc = 'Center window of previous horizontal split',
-        })
-        vim.api.nvim_create_autocmd('WinLeave', {
-            group = augroup,
-            callback = function(_)
-                -- Remember the previous window id
-                previous_win_id = vim.api.nvim_get_current_win()
-            end,
-            desc = 'Save previous window id from split',
-        })
-        vim.api.nvim_create_autocmd('WinClosed', {
-            group = augroup,
-            callback = function(_)
-                previous_win_id = 0
-            end,
-            desc = 'Reset previous window id from closed split',
-        })
     end
 
     if config.ui.signcolumn then

--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -47,7 +47,6 @@ function M.autoresize(config)
     end
 
     local win = vim.api.nvim_get_current_win()
-    local view = vim.fn.winsaveview()
     local cur_h = vim.api.nvim_win_get_height(win)
     local cur_w = vim.api.nvim_win_get_width(win)
 
@@ -57,7 +56,6 @@ function M.autoresize(config)
     if height > cur_h then
         vim.api.nvim_win_set_height(win, height)
     end
-    vim.fn.winrestview(view)
 end
 
 function M.equalise()
@@ -68,10 +66,8 @@ function M.maximise()
     local width, height = vim.o.columns, vim.o.lines
 
     local win = vim.api.nvim_get_current_win()
-    local view = vim.fn.winsaveview()
     vim.api.nvim_win_set_width(win, width)
     vim.api.nvim_win_set_height(win, height)
-    vim.fn.winrestview(view)
 end
 
 M.goal = 'autoresize'

--- a/tests/test_autoresize.lua
+++ b/tests/test_autoresize.lua
@@ -86,8 +86,8 @@ T['autoresize']['split'] = function()
     validate_win_dims(win_id_lower, { 80, 7 })
 
     -- Check if the window has been centered on line 15
-    eq(child.fn.line('w0', win_id_lower), 12)
-    eq(child.fn.line('w$', win_id_lower), 18)
+    eq(child.fn.line('w0', win_id_lower), 11)
+    eq(child.fn.line('w$', win_id_lower), 17)
 
     -- Switch windows
     child.cmd('wincmd w')
@@ -97,8 +97,8 @@ T['autoresize']['split'] = function()
     validate_win_dims(win_id_lower, { 80, 15 })
 
     -- Check if the window has been centered on line 15
-    eq(child.fn.line('w0', win_id_upper), 12)
-    eq(child.fn.line('w$', win_id_upper), 18)
+    eq(child.fn.line('w0', win_id_upper), 11)
+    eq(child.fn.line('w$', win_id_upper), 17)
 end
 
 T['autoresize']['split height'] = function()


### PR DESCRIPTION
The `splitkeep` option manages how window views are affected by switching / resizing windows. `focus.nvim` should probably follow the behavior of this option instead of using `feedkeys` to center windows with `zz`.

This PR adds an option to disable auto-centering for people using `splitkeep`. It also removes some uses of `winrestview` that were not necessary and caused some flickering with `mini.animate`.