### PR TITLE
fix: ensure autoresize won't affect cmdheight

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -53,7 +53,7 @@ function M.autoresize(config)
     if cur_w < vim.o.columns then
         vim.api.nvim_win_set_width(win, width)
     end
-    if cur_h < (vim.o.lines - 2) then
+    if cur_h < (vim.o.lines - vim.o.cmdheight - 2) then
         vim.api.nvim_win_set_height(win, height)
     end
 end

--- a/tests/test_autoresize.lua
+++ b/tests/test_autoresize.lua
@@ -384,4 +384,16 @@ T['autoresize']['golden ratio sizes (complex)'] = function()
     validate_win_dims(win_id_lower, { 80, 7 })
 end
 
+T['autoresize']['does not modify cmdheight'] = function()
+    child.o.cmdheight = 1
+
+    child.cmd('FocusMaximise')
+
+    child.cmd('vsplit')
+
+    child.cmd('FocusAutoresize')
+
+    eq(child.o.cmdheight, 1)
+end
+
 return T


### PR DESCRIPTION
`nvim_win_set_height` will change cmdheight if there is only one row in the layout and it is set to a height smaller than the available size. This checks cmdheight before resizing a window to avoid this issue.

fixes #131