### PR TITLE
feat: allow disabling focus for individual buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ vim.highlight.link('UnfocusedWindow', 'VisualNOS', true)
 
 ## Disabling Focus
 
-Focus can be disabled by setting a variable for just one window
-(`vim.w.focus_disable = true`) or globally (`vim.g.focus_disable = true`).
+Focus can be disabled by setting a variable for just one window,
+(`vim.w.focus_disable = true`), just one buffer (`vim.b.focus_disable = true`), or globally (`vim.g.focus_disable = true`).
 
 If you want to disable Focus for certain buffer or file types you can do
 this by setting up autocommands (`:help autocmd`) in your configuration.
@@ -346,9 +346,9 @@ vim.api.nvim_create_autocmd('FileType', {
     group = augroup,
     callback = function(_)
         if vim.tbl_contains(ignore_filetypes, vim.bo.filetype) then
-            vim.w.focus_disable = true
+            vim.b.focus_disable = true
         else
-            vim.w.focus_disable = false
+            vim.b.focus_disable = false
         end
     end,
     desc = 'Disable focus autoresize for FileType',

--- a/doc/focus.txt
+++ b/doc/focus.txt
@@ -90,7 +90,7 @@ default settings:
             relativenumber = false, -- Display relative line numbers in the focussed window only
             hybridnumber = false, -- Display hybrid line numbers in the focussed window only
             absolutenumber_unfocussed = false, -- Preserve absolute numbers in the unfocussed windows
-    
+
             cursorline = true, -- Display a cursorline in the focussed window only
             cursorcolumn = false, -- Display cursorcolumn in the focussed window only
             colorcolumn = {
@@ -283,7 +283,7 @@ buffer**
     -- Enable auto highlighting for focussed/unfocussed windows
     -- Default: false
     require("focus").setup({ ui = { winhighlight = true } })
-    
+
     -- By default, the highlight groups are setup as such:
     --   hi default link FocusedWindow VertSplit
     --   hi default link UnfocusedWindow Normal
@@ -307,10 +307,10 @@ Here is an example:
 >lua
     local ignore_filetypes = { 'neo-tree' }
     local ignore_buftypes = { 'nofile', 'prompt', 'popup' }
-    
+
     local augroup =
         vim.api.nvim_create_augroup('FocusDisable', { clear = true })
-    
+
     vim.api.nvim_create_autocmd('WinEnter', {
         group = augroup,
         callback = function(_)
@@ -323,14 +323,14 @@ Here is an example:
         end,
         desc = 'Disable focus autoresize for BufType',
     })
-    
+
     vim.api.nvim_create_autocmd('FileType', {
         group = augroup,
         callback = function(_)
             if vim.tbl_contains(ignore_filetypes, vim.bo.filetype) then
-                vim.w.focus_disable = true
+                vim.b.focus_disable = true
             else
-                vim.w.focus_disable = false
+                vim.b.focus_disable = false
             end
         end,
         desc = 'Disable focus autoresize for FileType',
@@ -462,7 +462,7 @@ LEVERAGE HJKL TO MOVE OR CREATE YOUR SPLITS DIRECTIONALLY ~
             require('focus').split_command(direction)
         end, { desc = string.format('Create or move to split (%s)', direction) })
     end
-    
+
     -- Use `<Leader>h` to split the screen to the left, same as command FocusSplitLeft etc
     focusmap('h')
     focusmap('j')

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -160,6 +160,21 @@ function Focus.focus_toggle_window()
     Focus.resize()
 end
 
+function Focus.focus_disable_buffer()
+    vim.b.focus_disable = true
+    Focus.resize()
+end
+
+function Focus.focus_enable_buffer()
+    vim.b.focus_disable = false
+    Focus.resize()
+end
+
+function Focus.focus_toggle_buffer()
+    vim.b.focus_disable = not vim.b.focus_disable
+    Focus.resize()
+end
+
 H.default_config = Focus.config
 
 H.setup_config = function(config)

--- a/lua/focus/modules/commands.lua
+++ b/lua/focus/modules/commands.lua
@@ -37,6 +37,24 @@ M.commands = {
         end,
         { nargs = 0 },
     },
+    FocusDisableBuffer = {
+        function()
+            require('focus').focus_disable_buffer()
+        end,
+        { nargs = 0 },
+    },
+    FocusEnableBuffer = {
+        function()
+            require('focus').focus_enable_buffer()
+        end,
+        { nargs = 0 },
+    },
+    FocusToggleBuffer = {
+        function()
+            require('focus').focus_toggle_buffer()
+        end,
+        { nargs = 0 },
+    },
     FocusEqualise = {
         function()
             require('focus').focus_equalise()

--- a/lua/focus/modules/utils.lua
+++ b/lua/focus/modules/utils.lua
@@ -29,7 +29,9 @@ function M.remove_from_set(set, item)
 end
 
 M.is_disabled = function()
-    return vim.g.focus_disable == true or vim.w.focus_disable == true
+    return vim.g.focus_disable == true
+        or vim.w.focus_disable == true
+        or vim.b.focus_disable == true
 end
 
 return M


### PR DESCRIPTION
The `FocusToggleWindow` commands previously used buffer-local vars, which was a bit counter-intuitive due to their names. However, changing that behavior removed the ability to toggle `focus` on a per-buffer basis, which can be useful for UI buffers like `neo-tree`. This PR adds back buffer-local vars to disable focus, and adds `Focus[Enable, Disable, Toggle]Buffer` commands.

In retrospect, I think moving to window-local vars was a mistake and we should have just renamed the `Window` commands to `Buffer` imo, but this allows for the same functionality without breaking anyone's configs.