### PR TITLE
fix: save and restore fixed win dimensions on resize

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -21,6 +21,33 @@ local golden_ratio_minheight = function()
     return math.floor(golden_ratio_height() / (3 * golden_ratio))
 end
 
+local function save_fixed_win_dims()
+    local fixed_dims = {}
+
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+        if vim.api.nvim_win_get_config(win).zindex == nil then
+            local buf = vim.api.nvim_win_get_buf(win)
+            if vim.w[win].focus_disable or vim.b[buf].focus_disable then
+                fixed_dims[win] = {
+                    width = vim.api.nvim_win_get_width(win),
+                    height = vim.api.nvim_win_get_height(win),
+                }
+            end
+        end
+    end
+
+    return fixed_dims
+end
+
+local function restore_fixed_win_dims(fixed_dims)
+    for win, dims in pairs(fixed_dims) do
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_set_width(win, dims.width)
+            vim.api.nvim_win_set_height(win, dims.height)
+        end
+    end
+end
+
 function M.autoresize(config)
     local width
     if config.autoresize.width > 0 then
@@ -49,8 +76,12 @@ function M.autoresize(config)
     -- save cmdheight to ensure it is not changed by nvim_win_set_height
     local cmdheight = vim.o.cmdheight
 
+    local fixed = save_fixed_win_dims()
+
     vim.api.nvim_win_set_width(0, width)
     vim.api.nvim_win_set_height(0, height)
+
+    restore_fixed_win_dims(fixed)
 
     vim.o.cmdheight = cmdheight
 end
@@ -62,9 +93,12 @@ end
 function M.maximise()
     local width, height = vim.o.columns, vim.o.lines
 
-    local win = vim.api.nvim_get_current_win()
-    vim.api.nvim_win_set_width(win, width)
-    vim.api.nvim_win_set_height(win, height)
+    local fixed = save_fixed_win_dims()
+
+    vim.api.nvim_win_set_width(0, width)
+    vim.api.nvim_win_set_height(0, height)
+
+    restore_fixed_win_dims(fixed)
 end
 
 M.goal = 'autoresize'


### PR DESCRIPTION
There is occasionally some flicker when switching windows, when some windows sizes are fixed (neo-tree, edgy.nvim, etc.), as Focus tries to resize them even if they are disabled when a neighboring window is resized.

This PR addresses this issue by saving and restoring the window dimensions of all disabled windows when resizing, ensuring that the layout stays consistent.

This makes a *huge* difference in some cases, and pretty much eliminates flickering entirely. It also solves the issue (#114) of windows being resized by their neighbors when they shouldn't be (without using `vim.fn.winlayout()`!), allowing for more predictable resize behavior overall.

closes #114 