### PR TITLE
refactor: use zindex for checking if win is float

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -110,7 +110,7 @@ function M.split_resizer(config, goal) --> Only resize normal buffers, set qf to
     if
         utils.is_disabled()
         or vim.api.nvim_win_get_option(0, 'diff')
-        or vim.api.nvim_win_get_config(0).relative ~= ''
+        or vim.api.nvim_win_get_config(0).zindex ~= nil
         or not config.autoresize.enable
     then
         vim.o.winwidth = 1

--- a/tests/test_autoresize.lua
+++ b/tests/test_autoresize.lua
@@ -396,4 +396,30 @@ T['autoresize']['does not modify cmdheight'] = function()
     eq(child.o.cmdheight, 1)
 end
 
+T['autoresize']['does not resize floating windows'] = function()
+    local win_id = child.api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 1,
+        col = 1,
+        width = 10,
+        height = 10,
+        style = 'minimal',
+    })
+
+    child.api.nvim_set_current_win(win_id)
+
+    eq(child.api.nvim_win_get_width(win_id), 10)
+    eq(child.api.nvim_win_get_height(win_id), 10)
+
+    child.cmd('FocusAutoresize')
+
+    eq(child.api.nvim_win_get_width(win_id), 10)
+    eq(child.api.nvim_win_get_height(win_id), 10)
+
+    child.cmd('FocusMaximise')
+
+    eq(child.api.nvim_win_get_width(win_id), 10)
+    eq(child.api.nvim_win_get_height(win_id), 10)
+end
+
 return T


### PR DESCRIPTION
Relative may soon be delegated to *only* floats (returning nil for splits), if that's the route I/we decide to take with [this PR in core](https://github.com/neovim/neovim/pull/25550/). This PR preemptively addresses that change by checking `zindex` instead of `relative` to determine whether a window is floating. This doesn't change any behavior now, so even if that PR isn't merged there will be no side-affects from this, but this ensures we don't break any user configs if/when it is merged.