### PR TITLE
Feature: Option to override bufnew

### DIFF
--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -98,18 +98,20 @@ Focus.resize = function(goal)
 end
 
 -- Exported internal functions for use in commands
-function Focus.split_nicely(args)
+function Focus.split_nicely(args, bufnew)
     local config = H.get_config()
     if args == nil then
         args = ''
     end
-    split.split_nicely(args, config.bufnew)
+    bufnew = bufnew or config.split.bufnew
+    split.split_nicely(args, bufnew)
 end
 
-function Focus.split_command(direction, args)
+function Focus.split_command(direction, args, bufnew)
     local config = H.get_config()
     args = args or ''
-    split.split_command(direction, args, config.split.tmux, config.split.bufnew)
+    bufnew = bufnew or config.split.bufnew
+    split.split_command(direction, args, config.split.tmux, bufnew)
 end
 
 function Focus.split_cycle(reverse)


### PR DESCRIPTION
Currently, the behavior of _bufnew_ is managed by configuration settings. This enhancement introduces the ability to override this configuration, enabling the creation of distinct keymaps for controlling bufnew.

```lua
-- keymap for splitting without bufnew
keymap('n', '<c-l>', function()
    require('focus').split_nicely("", false)
end, { desc = 'split nicely' })

-- keymap for splitting with bufnew
keymap('n', '<c-s-l>', function()
    require('focus').split_nicely("", true)
end, { desc = 'split nicely (bufnew)' })
```
