### PR TITLE
fix: incorrect cursor movement when `splitkeep=topline`

### DIFF
--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -109,7 +109,10 @@ function M.split_resizer(config, goal) --> Only resize normal buffers, set qf to
     end
     if
         utils.is_disabled()
-        or vim.api.nvim_win_get_option(0, 'diff')
+        or vim.api.nvim_get_option_value('diff', {
+            win = 0,
+            scope = 'local',
+        })
         or vim.api.nvim_win_get_config(0).zindex ~= nil
         or not config.autoresize.enable
     then


### PR DESCRIPTION
When `splitkeep=topline`, resizing windows while moving between them can cause the cursor to jump / end up in the wrong position. `vim.schedule`-ing the resize functions seems to fix this for me.

Also removed the use of `nvim_win_get_option`.