### PR TITLE
Check window width and height for focus_max_or_equal

### DIFF
--- a/lua/focus/modules/functions.lua
+++ b/lua/focus/modules/functions.lua
@@ -44,7 +44,9 @@ end
 
 M.focus_max_or_equal = function()
     local winwidth = vim.fn.winwidth(vim.api.nvim_get_current_win())
-    if winwidth > vim.o.columns / 2 then
+    local winheight = vim.fn.winheight(vim.api.nvim_get_current_win())
+    local bigger_than_half = (winwidth > vim.o.columns / 2) and (winheight > vim.o.lines / 2)
+    if bigger_than_half then
         M.focus_equalise()
     else
         M.focus_maximise()


### PR DESCRIPTION
At present it only checks for window width, which works for vertical splits. However, horizontal splits will not properly maximise since they will always have the max width, so attempts to focus_max_or_equal will always lead to focus_equalise.

Minimal repro setup:
```lua
-- minimal_init.lua
vim.env.LAZY_STDPATH = ".repro"
load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()

require("lazy.minit").repro({
    spec = {
        { 'nvim-focus/focus.nvim', version = false, lazy = false, opts = true }
    },
})
```

Repro:
1. `nvim -u minimal_init.lua`
2. Open a horizontal split (e.g. :split and :help lua)
3. Try running :FocusMaxOrEqual, it doesn't toggle the window sizing

https://github.com/user-attachments/assets/259980ed-d9a1-401a-888d-f915811e41f5

https://github.com/user-attachments/assets/fa6eda7c-ebbc-45dd-9a31-b0927bafccf4
