### PR TITLE
fix:  check for utils.disabled when changing signcolumn when leaving window

### DIFF
--- a/lua/focus/modules/autocmd.lua
+++ b/lua/focus/modules/autocmd.lua
@@ -60,6 +60,9 @@ function M.setup(config)
         vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
             group = augroup,
             callback = function(_)
+                if utils.is_disabled() then
+                    return
+                end
                 vim.wo.signcolumn = 'no'
             end,
             desc = 'Disable signcolumn',


### PR DESCRIPTION
#### Check if focus is disabled when changing signcolumn when leaving (WinLeave).

This solves the ``signcolumn`` getting changed upon lost focus of NvimTree window in floating mode despite being sure that NvimTree is in the ignore_filetypes.

```lua
    local ignore_filetypes = { 'neo-tree', 'NvimTree' }
    vim.api.nvim_create_autocmd('FileType', {
      group = augroup,
      callback = function(_)
        local is_floating = vim.api.nvim_win_get_config(0).relative ~= ''
        if vim.tbl_contains(ignore_filetypes, vim.bo.filetype) or is_floating then
          vim.b.focus_disable = true
          print('recognized focus filetype = ' .. vim.bo.filetype)
        else
          vim.b.focus_disable = false
        end
      end,
      desc = 'Disable focus autoresize for FileType',
    })

```

### Before 
Signcolumn disappear after losing focus
![image](https://github.com/user-attachments/assets/ae388462-753e-4332-997e-7a356bad5441)


### After 
Corectly keeps the signcolumn padding when cursor leaves NvimTree window
![image](https://github.com/user-attachments/assets/3d021ead-5962-4177-a542-955966a787dc)
