### PR TITLE
feat: add focused window minwidth and minheight options

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ require("focus").setup({
         height = 0, -- Force height for the focused window
         minwidth = 0, -- Force minimum width for the unfocused window
         minheight = 0, -- Force minimum height for the unfocused window
+        focusedwindow_minwidth = 0, --Force minimum width for the focused window
+        focusedwindow_minheight = 0, --Force minimum height for the focused window
         height_quickfix = 10, -- Set the height of quickfix panel
     },
     split = {
@@ -187,6 +189,13 @@ require("focus").setup({ autoresize = { width = 120 } })
 require("focus").setup({ autoresize = { minwidth = 80} })
 ```
 
+**Set Focus Minimum Width for Focused Window**
+```lua
+-- Force minimum width for the focused window
+-- Default: Calculated based on golden ratio
+require("focus").setup({ autoresize = { focusedwindow_minwidth = 80} })
+```
+
 **Set Focus Height**
 ```lua
 -- Force height for the focused window
@@ -199,6 +208,13 @@ require("focus").setup({ autoresize = { height = 40 } })
 -- Force minimum height for the unfocused window
 -- Default: 0
 require("focus").setup({ autoresize = { minheight = 10} })
+```
+
+**Set Focus Minimum Height for Focused Window**
+```lua
+-- Force minimum height for the focused window
+-- Default: Calculated based on golden ratio
+require("focus").setup({ autoresize = { focusedwindow_minheight = 80} })
 ```
 
 **Set Focus Quickfix Height**

--- a/doc/focus.txt
+++ b/doc/focus.txt
@@ -80,6 +80,8 @@ default settings:
             height = 0, -- Force height for the focused window
             minwidth = 0, -- Force minimum width for the unfocused window
             minheight = 0, -- Force minimum height for the unfocused window
+            focusedwindow_minwidth = 0, -- Force minimum width for the focused window
+            focusedwindow_minheight = 0, -- Force minimum height for the focused window
             height_quickfix = 10, -- Set the height of quickfix panel
         },
         split = {
@@ -91,7 +93,7 @@ default settings:
             relativenumber = false, -- Display relative line numbers in the focussed window only
             hybridnumber = false, -- Display hybrid line numbers in the focussed window only
             absolutenumber_unfocussed = false, -- Preserve absolute numbers in the unfocussed windows
-    
+
             cursorline = true, -- Display a cursorline in the focussed window only
             cursorcolumn = false, -- Display cursorcolumn in the focussed window only
             colorcolumn = {
@@ -154,6 +156,14 @@ SETUP OPTIONS ~
     require("focus").setup({ autoresize = { minwidth = 80} })
 <
 
+**Set Focus Minimum Width for Focused Window**
+
+>lua
+    -- Force minimum width for the focused window
+    -- Default: Calculated based on golden ratio
+    require("focus").setup({ autoresize = { focusedwindow_minwidth = 80} })
+<
+
 **Set Focus Height**
 
 >lua
@@ -168,6 +178,14 @@ SETUP OPTIONS ~
     -- Force minimum height for the unfocused window
     -- Default: 0
     require("focus").setup({ autoresize = { minheight = 10} })
+<
+
+**Set Focus Minimum Height for Focused Window**
+
+>lua
+    -- Force minimum height for the focused window
+    -- Default: Calculated based on golden ratio
+    require("focus").setup({ autoresize = { focusedwindow_minheight = 80} })
 <
 
 **Set Focus Quickfix Height**
@@ -287,7 +305,7 @@ buffer**
     -- Enable auto highlighting for focussed/unfocussed windows
     -- Default: false
     require("focus").setup({ ui = { winhighlight = true } })
-    
+
     -- By default, the highlight groups are setup as such:
     --   hi default link FocusedWindow VertSplit
     --   hi default link UnfocusedWindow Normal
@@ -312,10 +330,10 @@ Here is an example:
 >lua
     local ignore_filetypes = { 'neo-tree' }
     local ignore_buftypes = { 'nofile', 'prompt', 'popup' }
-    
+
     local augroup =
         vim.api.nvim_create_augroup('FocusDisable', { clear = true })
-    
+
     vim.api.nvim_create_autocmd('WinEnter', {
         group = augroup,
         callback = function(_)
@@ -328,7 +346,7 @@ Here is an example:
         end,
         desc = 'Disable focus autoresize for BufType',
     })
-    
+
     vim.api.nvim_create_autocmd('FileType', {
         group = augroup,
         callback = function(_)
@@ -473,7 +491,7 @@ LEVERAGE HJKL TO MOVE OR CREATE YOUR SPLITS DIRECTIONALLY ~
             require('focus').split_command(direction)
         end, { desc = string.format('Create or move to split (%s)', direction) })
     end
-    
+
     -- Use `<Leader>h` to split the screen to the left, same as command FocusSplitLeft etc
     focusmap('h')
     focusmap('j')

--- a/extras/repro.lua
+++ b/extras/repro.lua
@@ -37,6 +37,8 @@ require('focus').setup({
         height = 0, -- Force height for the focused window
         minwidth = 0, -- Force minimum width for the unfocused window
         minheight = 0, -- Force minimum height for the unfocused window
+        focusedwindow_minwidth = 0, -- Force minimum width for the focused window
+        focusedwindow_minheight = 0, -- Force minimum height for the focused window
         height_quickfix = 10, -- Set the height of quickfix panel
     },
     split = {

--- a/lua/focus/init.lua
+++ b/lua/focus/init.lua
@@ -27,6 +27,8 @@ Focus.config = {
         height = 0, -- Force height for the focused window
         minwidth = 0, -- Force minimum width for the unfocused window
         minheight = 0, -- Force minimum height for the unfocused window
+        focusedwindow_minwidth = 0, -- Force minimum width for the focused window
+        focusedwindow_minheight = 0, -- Force minimum height for the focused window
         height_quickfix = 10, -- Set the height of quickfix panel
     },
     split = {
@@ -196,6 +198,14 @@ H.setup_config = function(config)
         ['autoresize.height'] = { config.autoresize.height, 'number' },
         ['autoresize.minwidth'] = { config.autoresize.minwidth, 'number' },
         ['autoresize.minheight'] = { config.autoresize.minheight, 'number' },
+        ['autoresize.focusedwindow_minwidth'] = {
+            config.autoresize.focusedwindow_minwidth,
+            'number',
+        },
+        ['autoresize.focusedwindow_minheight'] = {
+            config.autoresize.focusedwindow_minheight,
+            'number',
+        },
         ['autoresize.height_quickfix'] = {
             config.autoresize.height_quickfix,
             'number',

--- a/lua/focus/modules/resizer.lua
+++ b/lua/focus/modules/resizer.lua
@@ -54,7 +54,11 @@ function M.autoresize(config)
         width = config.autoresize.width
     else
         width = golden_ratio_width()
-        if config.autoresize.minwidth > 0 then
+        if config.autoresize.focusedwindow_minwidth > 0 then
+            if width < config.autoresize.focusedwindow_minwidth then
+                width = config.autoresize.focusedwindow_minwidth
+            end
+        elseif config.autoresize.minwidth > 0 then
             width = math.max(width, config.autoresize.minwidth)
         elseif width < golden_ratio_minwidth() then
             width = golden_ratio_minwidth()
@@ -66,7 +70,11 @@ function M.autoresize(config)
         height = config.autoresize.height
     else
         height = golden_ratio_height()
-        if config.autoresize.minheight > 0 then
+        if config.autoresize.focusedwindow_minheight > 0 then
+            if height < config.autoresize.focusedwindow_minheight then
+                height = config.autoresize.focusedwindow_minheight
+            end
+        elseif config.autoresize.minheight > 0 then
             height = math.max(height, config.autoresize.minheight)
         elseif height < golden_ratio_minheight() then
             height = golden_ratio_minheight()
@@ -121,13 +129,19 @@ function M.split_resizer(config, goal) --> Only resize normal buffers, set qf to
         vim.o.winheight = 1
         return
     else
-        if config.autoresize.minwidth > 0 then
+        if
+            config.autoresize.minwidth > 0
+            and config.autoresize.focusedwindow_minwidth <= 0
+        then
             if vim.o.winwidth < config.autoresize.minwidth then
                 vim.o.winwidth = config.autoresize.minwidth
             end
             vim.o.winminwidth = config.autoresize.minwidth
         end
-        if config.autoresize.minheight > 0 then
+        if
+            config.autoresize.minheight > 0
+            and config.autoresize.focusedwindow_minheight <= 0
+        then
             if vim.o.winheight < config.autoresize.minheight then
                 vim.o.winheight = config.autoresize.minheight
             end


### PR DESCRIPTION
Adds options to set minimum width and height for the focused window. This allows users to customize the size of the focused window.

Missing tests and probably something else... If anyone has any pointers, I can continue working on this.

Motivation: I have a normal screen, but sometimes I have multiple windows with buffers open. I wanted to ensure that the focused window has at least 80 characters in width to read Markdown files comfortably.

Hope this helps the repository, which, by the way, is awesome!